### PR TITLE
Fix some error in RouterForComplexRoutes.

### DIFF
--- a/src/Middleware/RouterForComplexRoutes.php
+++ b/src/Middleware/RouterForComplexRoutes.php
@@ -19,6 +19,8 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class RouterForComplexRoutes implements MiddlewareInterface
 {
+    const CONTROLLER_METHOD_SEPARATOR = '::';
+    
     private $matcher;
     private $container;
 
@@ -41,9 +43,13 @@ class RouterForComplexRoutes implements MiddlewareInterface
         }
 
         // We expect $parameters['_controller'] to contain a string on format "ControllerClass::action"
+        if (!strpos($parameters['_controller'], self::CONTROLLER_METHOD_SEPARATOR)) {
+            throw new \LogicException(sprintf('Invalid route config for route "%s". "%s" expected.', $parameters['_route'], self::CONTROLLER_METHOD_SEPARATOR));
+        }
+        
         list($class, $method) = explode('::', $parameters['_controller'], 2);
         if (!$this->container->has($class)) {
-            throw new \LogicException(sprintf('Invalid route config for route "%s"', $parameters['route']));
+            throw new \LogicException(sprintf('Invalid route config for route "%s". Controller "%s" not found.', $parameters['_route'], $class));
         }
 
         $controller = [$this->container->get($class), $method];
@@ -68,6 +74,6 @@ class RouterForComplexRoutes implements MiddlewareInterface
             }
         }
 
-        return $arguments;
+        return $arguments ?? [];
     }
 }

--- a/src/Middleware/RouterForComplexRoutes.php
+++ b/src/Middleware/RouterForComplexRoutes.php
@@ -47,7 +47,7 @@ class RouterForComplexRoutes implements MiddlewareInterface
             throw new \LogicException(sprintf('Invalid route config for route "%s". "%s" expected.', $parameters['_route'], self::CONTROLLER_METHOD_SEPARATOR));
         }
         
-        list($class, $method) = explode('::', $parameters['_controller'], 2);
+        list($class, $method) = explode(self::CONTROLLER_METHOD_SEPARATOR, $parameters['_controller'], 2);
         if (!$this->container->has($class)) {
             throw new \LogicException(sprintf('Invalid route config for route "%s". Controller "%s" not found.', $parameters['_route'], $class));
         }


### PR DESCRIPTION
Hello,

First, congrats for this project. I love it!

This pull request fix two minors errors :
- If the controller method hasn't arguments, give it an empty array.
- If the container doesn't have the Controller service, fix the parameters route index to _route.

I also added an other check in order to see if the _controller parameter contains the correct separator (here "::"). This separator is now a constant to change it easily.

This helped me to be more explicit about the encounter \LogicException.

What do you think about it?

Thanks you for this little project